### PR TITLE
FIX Transparent SVG

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,12 +33,11 @@ export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 
 
 Required packages for Python scripts:
-
-`pip install CairoSVG`
-
 `pip install PyPDF2`
 
+librsvg2-bin required for svg to pdf conversion (`rsvg-convert`)
 
+`sudo apt-get install librsvg2-bin`
 Run with `go run main.go`
 
 

--- a/pdfop/pdfop.go
+++ b/pdfop/pdfop.go
@@ -87,12 +87,13 @@ func SvgToPdf(fileName string, outputDir string, prefix string) {
 			panic(err)
 		}
 	}
-
-	log.WithFields(log.Fields{"fileName": fileName, "outputDir": outputDir, "prefix": prefix}).Info("Converting SVG files to a single PDF")
-	cmd := exec.Command("python3", config.SCRIPT_PATH+"svgtopdf.py", "-n", prefix, "-o", outputDir, "-p", fileName)
-	err := cmd.Run()
-	if err != nil {
-		panic(err)
+	files, _ := ioutil.ReadDir(fileName)
+	for i := range files {
+		cmd := exec.Command("rsvg-convert", "-f", "pdf", "-o", outputDir+"/"+prefix+"_"+strconv.Itoa(i)+".pdf", fileName+"/slide"+strconv.Itoa(i+1)+".svg")
+		err := cmd.Run()
+		if err != nil {
+			panic(err)
+		}
 	}
 }
 


### PR DESCRIPTION
use rsvg-convert command instead of svgtopdf.py 

issue:
cairosvg.svg2pdf can't handle transparent background on objects in svg so their background will be black.

This is fixed when using rsvg-convert for the svg to pdf conversion.